### PR TITLE
fix regular expression

### DIFF
--- a/lib/srcset.php
+++ b/lib/srcset.php
@@ -29,7 +29,7 @@ class rex_media_srcset
         }
 
         // get all PICTURE elements with srcset attribute
-        preg_match_all('/<picture([^>]+)?>(.*)<\/picture>/is', $content, $matches, PREG_SET_ORDER);
+        preg_match_all('/<picture([^>]+)?>(.*?)<\/picture>/is', $content, $matches, PREG_SET_ORDER);
         if(!empty($matches[0]))
         {
             $elements = array_merge($elements, $matches);


### PR DESCRIPTION
Fixes: #19 

Mit diesem Fix werden die Picture Tags korrekt erkannt, wenn mehrere auf einer Seite sind. Ohne das Fragezeichen hatte ich im ersten Match bereits 2 picture tags und die Ersetzung schlug fehl

https://stackoverflow.com/questions/781897/regex-matching-exactly-one-single-tag/781911#781911
Hat geholfen.

„The usual warnings about using regex to process HTML apply: You shouldn’t.” ;-)

Vielleicht sollten wir irgendwann auf DOMDocument umsteigen.